### PR TITLE
feat: Implement manga search by name for KingofShojo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,86 @@
-import React, { useState, ChangeEvent, FormEvent } from "react"; // Import ChangeEvent and FormEvent types
+import React, { useState, ChangeEvent, FormEvent } from "react";
 import { motion } from "framer-motion";
-import { Download, BookOpen, Loader, CheckCircle, AlertTriangle, List } from "lucide-react";
+import { Download, Loader, List, Search } from "lucide-react"; // Added Search icon
 
 // Define an interface for your chapter data structure
 interface Chapter {
   title: string;
-  // Add other properties if your chapter objects have them (e.g., url: string;)
-  // id: string | number; // It's generally better to use a stable ID for keys if available
+  // url: string; // Example: if you also store URLs directly with chapters
 }
 
+// Define an interface for search results
+interface SearchResult {
+  title: string;
+  url: string;
+}
 
 function App() {
   const [mangaUrl, setMangaUrl] = useState("");
-  const [chapters, setChapters] = useState<Chapter[]>([]); // <-- Type the state variable
+  const [chapters, setChapters] = useState<Chapter[]>([]);
   const [selectedStart, setSelectedStart] = useState("");
   const [selectedEnd, setSelectedEnd] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [status, setStatus] = useState<{ type: string, message: string }>({ type: "", message: "" }); // <-- Type the status state
-  const [siteType, setSiteType] = useState<string | null>(null); // <-- Type the siteType state
+  const [loading, setLoading] = useState(false); // Used for chapter fetching & PDF generation
+  const [status, setStatus] = useState<{ type: string, message: string }>({ type: "", message: "" });
+  const [siteType, setSiteType] = useState<string | null>(null);
+
+  // New state variables for manga search
+  const [mangaName, setMangaName] = useState("");
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchAttempted, setSearchAttempted] = useState(false); // To track if a search has been made
 
   // Helper function to get error message from unknown type
   const getErrorMessage = (error: unknown): string => {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    return 'An unknown error occurred.';
+  };
+
+  // Function to handle manga search
+  const handleSearchManga = async () => {
+    if (mangaName.trim() === "") return;
+
+    setIsSearching(true);
+    setSearchResults([]);
+    setSearchAttempted(true); // Mark that a search has been attempted
+    setStatus({ type: "", message: "" }); // Clear previous general statuses
+
+    try {
+      // Assuming backend is running on localhost:5000
+      const response = await fetch("http://localhost:5000/search-manga", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mangaName, site: "kingofshojo" }), // Site is fixed for now
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.json(); // Assuming server sends JSON error
+        throw new Error(errorBody.error || `Server responded with status ${response.status}`);
+      }
+
+      const data = await response.json();
+      // data.error should ideally be caught by !response.ok if the server correctly sets status codes for JSON error responses.
+      // However, an explicit check can be a fallback.
+      if (data.error) {
+        throw new Error(data.error);
+      }
+
+      setSearchResults(data as SearchResult[]); // Assuming data is SearchResult[]
+      if (data.length === 0) {
+        // Optional: set a status if needed, though "No results found" is handled by conditional rendering
+        // setStatus({ type: "info", message: "No manga found matching your search." });
+      }
+      // No specific status message for successful search, results display is the feedback
+
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
+      setStatus({ type: "error", message: `Search failed: ${message}` });
+      setSearchResults([]); // Clear results on error
+    } finally {
+      setIsSearching(false);
+    }
+  };
       if (error instanceof Error) {
           return error.message;
       }
@@ -130,54 +190,124 @@ function App() {
           >
             📖 Comic to PDF Converter
           </motion.h1>
-          <p className="text-gray-400">Download any comic as PDFs.</p>
+          <p className="text-gray-400">Search for manga or enter a URL to download chapters as PDFs.</p>
         </div>
 
-        <form className="space-y-6" onSubmit={handleDownload}> {/* Add onSubmit to form */}
+        {/* Manga Search Section */}
+        <div className="space-y-4 mb-6">
           <div>
-            <label htmlFor="manga-url" className="block text-sm font-medium text-gray-300 mb-2">Enter Manga URL</label> {/* Added htmlFor */}
+            <label htmlFor="manga-name-search" className="block text-sm font-medium text-gray-300 mb-2">
+              Search Manga Name (KingofShojo only)
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                id="manga-name-search"
+                value={mangaName}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  setMangaName(e.target.value);
+                  setSearchAttempted(false); // Reset search attempted when user types
+                  setSearchResults([]); // Clear previous results when user types
+                }}
+                placeholder="E.g., My Happy Marriage"
+                className="block w-full px-4 py-3 border border-gray-600 bg-gray-700 text-white rounded-lg focus:ring-2 focus:ring-blue-400"
+              />
+              <button
+                type="button"
+                onClick={handleSearchManga}
+                disabled={isSearching || mangaName.trim() === ""}
+                className="flex items-center justify-center gap-2 py-3 px-4 border border-transparent rounded-lg shadow-sm text-white bg-purple-600 hover:bg-purple-700 focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 disabled:opacity-50"
+                style={{ minWidth: '120px' }} // Ensure button width is consistent
+              >
+                {isSearching ? (
+                  <>
+                    <Loader className="animate-spin h-5 w-5" /> Searching...
+                  </>
+                ) : (
+                  <>
+                    <Search className="h-5 w-5" /> Search
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+
+          {/* Display Search Results */}
+          {isSearching && searchResults.length === 0 && (
+             <div className="text-center text-gray-400">Searching for manga...</div>
+          )}
+          {!isSearching && searchAttempted && searchResults.length === 0 && (
+            <div className="text-center text-gray-400 bg-gray-700 p-3 rounded-lg">No results found for "{mangaName}". Try a different name.</div>
+          )}
+          {searchResults.length > 0 && (
+            <div className="space-y-2 bg-gray-750 p-4 rounded-lg max-h-60 overflow-y-auto">
+              <h3 className="text-md font-semibold text-gray-200 mb-2">Search Results:</h3>
+              {searchResults.map((result) => (
+                <div key={result.url} className="p-3 bg-gray-700 rounded-md hover:bg-gray-600 transition-colors">
+                  <p className="font-medium text-blue-300">{result.title}</p>
+                  <button
+                    onClick={() => {
+                      setMangaUrl(result.url);
+                      setSearchResults([]); // Clear results
+                      setMangaName(""); // Clear search input
+                      setSearchAttempted(false);
+                      // Optionally, trigger fetchChapters directly or let user click "Fetch Chapters"
+                      // fetchChapters(); // If you want to auto-fetch after selection
+                    }}
+                    className="text-sm text-purple-400 hover:text-purple-300 mt-1"
+                  >
+                    Use this URL
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+        {/* End Manga Search Section */}
+
+        <form className="space-y-6" onSubmit={handleDownload}>
+          <div>
+            <label htmlFor="manga-url" className="block text-sm font-medium text-gray-300 mb-2">
+              Enter Manga URL (or select from search results)
+            </label>
             <input
               type="url"
-              id="manga-url" // Added id
+              id="manga-url"
               value={mangaUrl}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setMangaUrl(e.target.value)} // <-- Type the event
-              placeholder="Enter the comic interface URL Example: https://kingofshojo.com/manga/solo-leveling/"
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setMangaUrl(e.target.value)}
+              placeholder="Enter the comic interface URL or use search above"
               className="block w-full px-4 py-3 border border-gray-600 bg-gray-700 text-white rounded-lg focus:ring-2 focus:ring-blue-400"
               required
             />
           </div>
 
           <button
-            type="button" // Keep type="button" if you don't want this to submit the form normally
+            type="button"
             onClick={fetchChapters}
-            disabled={loading}
+            disabled={loading || !mangaUrl.trim()} // Also disable if mangaUrl is empty
             className="w-full flex items-center justify-center gap-2 py-3 px-4 border border-transparent rounded-lg shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
           >
-            {loading ? <Loader className="animate-spin h-5 w-5" /> : <List className="h-5 w-5" />}
-            {loading ? "Loading Chapters..." : "Fetch Chapters"}
+            {loading && !isSearching ? <Loader className="animate-spin h-5 w-5" /> : <List className="h-5 w-5" />}
+            {loading && !isSearching ? "Loading Chapters..." : "Fetch Chapters"}
           </button>
 
           {chapters.length > 0 && (
             <div className="grid grid-cols-2 gap-4">
               <select
                 value={selectedStart}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => setSelectedStart(e.target.value)} // <-- Type the event
+                onChange={(e: ChangeEvent<HTMLSelectElement>) => setSelectedStart(e.target.value)}
                 className="block w-full px-4 py-2 border border-gray-600 bg-gray-700 text-white rounded-lg focus:ring-2 focus:ring-blue-400"
               >
-                {/* Ensure chapter is typed as Chapter */}
-                {chapters.map((chapter: Chapter) => (
-                  // Using title as key - ideally use a unique ID if available in your data
+                {chapters.map((chapter) => (
                   <option key={chapter.title} value={chapter.title}>{chapter.title}</option>
                 ))}
               </select>
               <select
                 value={selectedEnd}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => setSelectedEnd(e.target.value)} // <-- Type the event
+                onChange={(e: ChangeEvent<HTMLSelectElement>) => setSelectedEnd(e.target.value)}
                 className="block w-full px-4 py-2 border border-gray-600 bg-gray-700 text-white rounded-lg focus:ring-2 focus:ring-blue-400"
               >
-                 {/* Ensure chapter is typed as Chapter */}
-                {chapters.map((chapter: Chapter) => (
-                   // Using title as key - ideally use a unique ID if available in your data
+                {chapters.map((chapter) => (
                   <option key={chapter.title} value={chapter.title}>{chapter.title}</option>
                 ))}
               </select>
@@ -189,12 +319,12 @@ function App() {
             disabled={loading || chapters.length === 0}
             className="w-full flex items-center justify-center gap-2 py-3 px-4 border border-transparent rounded-lg shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
           >
-            {loading ? <Loader className="animate-spin h-5 w-5" /> : <Download className="h-5 w-5" />}
-            {loading ? "Converting..." : "Download PDF"}
+            {loading && !isSearching ? <Loader className="animate-spin h-5 w-5" /> : <Download className="h-5 w-5" />}
+            {loading && !isSearching ? "Converting..." : "Download PDF"}
           </button>
         </form>
 
-        {/* Display Status Messages */}
+        {/* Display Status Messages - including search status */}
          {status.message && (
              <motion.div
                 initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
This commit introduces a new feature allowing you to search for manga by name directly within the application, initially supporting kingofshojo.com.

Key changes:

Backend (`backend/server.js`):
- Added a new POST endpoint `/search-manga` that accepts `mangaName` and `site`.
- For `site: 'kingofshojo'`, it fetches search results from `kingofshojo.com/?s=<mangaName>`.
- Parses the HTML response using Cheerio to extract manga titles and URLs.
- Returns a JSON array of search results `{ title, url }`.
- Includes error handling for invalid input, network issues, and parsing failures.

Frontend (`src/App.tsx`):
- Added a new input field for manga name and a "Search" button.
- Implemented `handleSearchManga` function to call the `/search-manga` backend API.
- Displays search results, loading states, and "no results found" messages.
- Allows you to select a manga from the search results, which populates the existing manga URL input field.
- The "Fetch Chapters" functionality then uses this URL as before.
- Styled new UI elements consistently with the existing application design.

This enhancement improves your experience by removing the need to manually find the manga URL on kingofshojo.com before being able to fetch its chapters.