### PR TITLE
fix: Resolve 'return outside of function' error in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,12 +81,6 @@ function App() {
       setIsSearching(false);
     }
   };
-      if (error instanceof Error) {
-          return error.message;
-      }
-      // You could add more checks here if you expect other error shapes
-      return 'An unknown error occurred.';
-  };
 
 
   // Fetch chapters based on URL


### PR DESCRIPTION
This commit fixes a critical syntax error in `src/App.tsx` that caused a "'return' outside of function" Vite/Babel compilation error.

The error was due to a duplicated, non-functional block of code resembling the `getErrorMessage` helper function. This stray code was inadvertently introduced during the implementation of the manga search feature and contained `return` statements that were not correctly scoped within a function.

The fix involves removing the erroneous, duplicated code block, ensuring that the legitimate `getErrorMessage` function and all other component logic remain intact and correctly structured.