### PR TITLE
feat: Add scroll mode and default zoom to comic reader

### DIFF
--- a/src/ComicReader.tsx
+++ b/src/ComicReader.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Loader, X, ArrowLeft, ArrowRight, ZoomIn, ZoomOut, Maximize, Minimize } from "lucide-react";
+import { Loader, X, ArrowLeft, ArrowRight, ZoomIn, ZoomOut, Maximize, Minimize, View } from "lucide-react";
 
 interface ComicReaderProps {
   chapterUrl: string;
@@ -12,8 +12,9 @@ const ComicReader: React.FC<ComicReaderProps> = ({ chapterUrl, siteType, onClose
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(0);
-  const [zoomLevel, setZoomLevel] = useState(1);
+  const [zoomLevel, setZoomLevel] = useState(3);
   const [isFullScreen, setIsFullScreen] = useState(false);
+  const [viewMode, setViewMode] = useState<'single' | 'scroll'>('single');
   const readerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -86,11 +87,14 @@ const ComicReader: React.FC<ComicReaderProps> = ({ chapterUrl, siteType, onClose
         <div className="flex justify-between items-center p-4 border-b border-gray-700">
           <h2 className="text-xl font-bold text-white">Reading Chapter</h2>
           <div className="flex items-center space-x-4">
-            <button onClick={() => setZoomLevel(z => z + 0.1)} className="text-gray-400 hover:text-white">
+            <button onClick={() => setZoomLevel(z => z + 0.1)} className="text-gray-400 hover:text-white" disabled={viewMode === 'scroll'}>
               <ZoomIn size={24} />
             </button>
-            <button onClick={() => setZoomLevel(z => Math.max(0.1, z - 0.1))} className="text-gray-400 hover:text-white">
+            <button onClick={() => setZoomLevel(z => Math.max(0.1, z - 0.1))} className="text-gray-400 hover:text-white" disabled={viewMode === 'scroll'}>
               <ZoomOut size={24} />
+            </button>
+            <button onClick={() => setViewMode(m => m === 'single' ? 'scroll' : 'single')} className="text-gray-400 hover:text-white">
+              <View size={24} />
             </button>
             <button onClick={toggleFullScreen} className="text-gray-400 hover:text-white">
               {isFullScreen ? <Minimize size={24} /> : <Maximize size={24} />}
@@ -113,36 +117,46 @@ const ComicReader: React.FC<ComicReaderProps> = ({ chapterUrl, siteType, onClose
             </div>
           )}
           {!loading && !error && imageUrls.length > 0 && (
-            <div className="flex flex-col items-center justify-center h-full">
-              <img
-                src={imageUrls[currentPage]}
-                alt={`Page ${currentPage + 1}`}
-                className="max-w-full max-h-full object-contain"
-                style={{ transform: `scale(${zoomLevel})` }}
-              />
-            </div>
+            viewMode === 'single' ? (
+              <div className="flex flex-col items-center justify-center h-full">
+                <img
+                  src={imageUrls[currentPage]}
+                  alt={`Page ${currentPage + 1}`}
+                  className="max-w-full max-h-full object-contain"
+                  style={{ transform: `scale(${zoomLevel})` }}
+                />
+              </div>
+            ) : (
+              <div className="flex flex-col items-center space-y-2">
+                {imageUrls.map((url, index) => (
+                  <img key={index} src={url} alt={`Page ${index + 1}`} className="max-w-full h-auto" />
+                ))}
+              </div>
+            )
           )}
         </div>
 
-        <div className="flex justify-between items-center p-4 border-t border-gray-700">
-          <button
-            onClick={() => setCurrentPage(p => Math.max(0, p - 1))}
-            disabled={currentPage === 0}
-            className="p-2 rounded-full bg-gray-700 hover:bg-gray-600 disabled:opacity-50"
-          >
-            <ArrowLeft size={24} />
-          </button>
-          <div className="text-white">
-            {currentPage + 1} / {imageUrls.length}
+        {viewMode === 'single' && (
+          <div className="flex justify-between items-center p-4 border-t border-gray-700">
+            <button
+              onClick={() => setCurrentPage(p => Math.max(0, p - 1))}
+              disabled={currentPage === 0}
+              className="p-2 rounded-full bg-gray-700 hover:bg-gray-600 disabled:opacity-50"
+            >
+              <ArrowLeft size={24} />
+            </button>
+            <div className="text-white">
+              {currentPage + 1} / {imageUrls.length}
+            </div>
+            <button
+              onClick={() => setCurrentPage(p => Math.min(imageUrls.length - 1, p + 1))}
+              disabled={currentPage === imageUrls.length - 1}
+              className="p-2 rounded-full bg-gray-700 hover:bg-gray-600 disabled:opacity-50"
+            >
+              <ArrowRight size={24} />
+            </button>
           </div>
-          <button
-            onClick={() => setCurrentPage(p => Math.min(imageUrls.length - 1, p + 1))}
-            disabled={currentPage === imageUrls.length - 1}
-            className="p-2 rounded-full bg-gray-700 hover:bg-gray-600 disabled:opacity-50"
-          >
-            <ArrowRight size={24} />
-          </button>
-        </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
This commit introduces two new features to the online comic reader to enhance the user experience:

- **Scroll Mode:** A new "Scroll" view mode has been added, which displays all chapter images in a single, scrollable container. This provides an alternative to the single-page view. A toggle button has been added to switch between view modes.
- **Default Zoom:** The default zoom level for the single-page view has been set to 300% to improve readability on high-resolution displays.
- **UI Adjustments:** The zoom controls are now disabled when in scroll mode, as they are not applicable.